### PR TITLE
corrected param name "Monitor" to "InputSource and provided "Monitor" param to provide multi-display support

### DIFF
--- a/switchdell.ps1
+++ b/switchdell.ps1
@@ -1,19 +1,33 @@
 Param
-          (
-            [parameter(Mandatory=$false)]
-            [ValidateSet("HDMI", "mDP","DP2","MHL","DP1","DP")]
-            [String[]]
-            $Monitor="HDMI"
-          ) 
-if($Monitor -eq "DP")
-{
-	$Monitor="DP1"
+(
+    [parameter(Mandatory = $false)]
+    [ValidateSet("HDMI", "mDP", "DP2", "MHL", "DP1", "DP")]
+    [String[]]
+    $InputSource = "HDMI",
+    [ValidateRange(1, 63)] 
+    [Int]    
+    $Monitor = 1
+) 
+$Host.UI.RawUI.BackgroundColor = 1; 
+$Host.UI.RawUI.ForegroundColor = 15;
+Clear-Host
+if ($InputSource -eq "DP") {
+    $InputSource = "DP1"
 }
-if($Monitor -eq "mdp")
-{
-	$Monitor="DP2"
+if ($InputSource -eq "mdp") {
+    $InputSource = "DP2"
 }
-$ddmpath="C:\Program Files (x86)\Dell\Dell Display Manager\ddm.exe"
-$setinput="/SetActiveInput"
-Write-Host "Attempting to switch to monitor" $Monitor
-& $ddmpath $setinput $Monitor
+
+if ($Monitor -eq "1") {
+    $MonitorActiveInput = "/SetActiveInput"
+}
+else {
+    $MonitorActiveInput = "/$($Monitor):SetActiveInput"
+}
+
+$exit = "/exit"
+$ddmpath = "C:\Program Files (x86)\Dell\Dell Display Manager\ddm.exe"
+Write-Host "Attempting to switch Display $($Monitor) to InputSource $($InputSource)..."
+& $ddmpath $MonitorActiveInput $InputSource $exit
+
+Start-Sleep 5


### PR DESCRIPTION
I really like you script, but since I'm using two displays I thought it would be nice to support more than one display to be changed through the script.
The other thing changed is that in fact we're not switching the "monitor" but the InputSource. So I rededicated the param "Monitor" to switch through the single display attached and renamed the old "monitor" param to "InputSource".

Other things changed:
"Write-Host" is now shown for 5 seconds and the console is blue now.